### PR TITLE
feat: support custom Tailscale Serve paths

### DIFF
--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -65,6 +65,7 @@ services:
       - "docktail.service.protocol=http"
       - "docktail.service.service-port=80"
       - "docktail.service.service-protocol=http"
+      - "docktail.service.path=/api"
 
   # HTTPS service protocol
   test-proto-https:

--- a/docker/client.go
+++ b/docker/client.go
@@ -253,6 +253,27 @@ func parseProxyProtocol(value, serviceProtocol string) (int, error) {
 	}
 }
 
+// parseServicePath validates docktail.service.path. HTTP/HTTPS services use
+// the root handler by default. TCP forwarding has no URL handler, so declaring
+// a path there is an error rather than a silently ignored label.
+func parseServicePath(rawPath string, declared bool, serviceProtocol string) (string, error) {
+	if declared && serviceProtocol != "http" && serviceProtocol != "https" {
+		return "", fmt.Errorf("%s is only supported for HTTP/HTTPS services", apptypes.LabelServicePath)
+	}
+	if serviceProtocol != "http" && serviceProtocol != "https" {
+		return "", nil
+	}
+
+	path := strings.TrimSpace(rawPath)
+	if path == "" {
+		return "/", nil
+	}
+	if !strings.HasPrefix(path, "/") {
+		return "", fmt.Errorf("invalid service path: %s (must start with /)", rawPath)
+	}
+	return path, nil
+}
+
 // resolveDestPort determines the destination IP and port based on networking mode.
 // Returns (destIP, destPort, error).
 func (c *Client) resolveDestPort(cctx *containerCtx, targetPort string) (string, string, error) {
@@ -787,6 +808,11 @@ func (c *Client) parseContainer(ctx context.Context, containerID string, labels 
 		if err != nil {
 			return nil, err
 		}
+		servicePathLabel, hasServicePath := labels[apptypes.LabelServicePath]
+		servicePath, err := parseServicePath(servicePathLabel, hasServicePath, serviceProtocol)
+		if err != nil {
+			return nil, err
+		}
 
 		primary := &apptypes.ContainerService{
 			ContainerID:        cctx.containerID[:12],
@@ -797,6 +823,7 @@ func (c *Client) parseContainer(ctx context.Context, containerID string, labels 
 			Port:               port,
 			TargetPort:         destPort,
 			ServiceProtocol:    serviceProtocol,
+			ServicePath:        servicePath,
 			Protocol:           protocol,
 			ProxyProtocol:      proxyProtocol,
 			Tags:               cctx.tags,
@@ -937,6 +964,17 @@ func (c *Client) parseIndexedPorts(
 				Msg("Invalid proxy-protocol for indexed service, skipping")
 			continue
 		}
+		idxServicePathLabel, hasIdxServicePath := labels[prefix+"path"]
+		idxServicePath, err := parseServicePath(idxServicePathLabel, hasIdxServicePath, serviceProtocol)
+		if err != nil {
+			log.Warn().
+				Err(err).
+				Str("container", cctx.containerName).
+				Str("service", idxServiceName).
+				Int("index", idx).
+				Msg("Invalid path for indexed service, skipping")
+			continue
+		}
 
 		// Check for duplicate service name + port combo
 		dedupKey := idxServiceName + ":" + servicePort
@@ -982,6 +1020,7 @@ func (c *Client) parseIndexedPorts(
 			Port:               servicePort,
 			TargetPort:         idxDestPort,
 			ServiceProtocol:    serviceProtocol,
+			ServicePath:        idxServicePath,
 			Protocol:           protocol,
 			ProxyProtocol:      idxProxyProtocol,
 			Tags:               cctx.tags,

--- a/docker/client_test.go
+++ b/docker/client_test.go
@@ -327,6 +327,42 @@ func TestParseProxyProtocol(t *testing.T) {
 	}
 }
 
+func TestParseServicePath(t *testing.T) {
+	tests := []struct {
+		name            string
+		value           string
+		declared        bool
+		serviceProtocol string
+		want            string
+		wantError       bool
+	}{
+		{name: "unset HTTP defaults to root", serviceProtocol: "http", want: "/"},
+		{name: "custom HTTPS path", value: "/api", declared: true, serviceProtocol: "https", want: "/api"},
+		{name: "trims whitespace", value: " /api/v1 ", declared: true, serviceProtocol: "http", want: "/api/v1"},
+		{name: "TCP has no path", serviceProtocol: "tcp", want: ""},
+		{name: "rejects path without slash", value: "api", declared: true, serviceProtocol: "http", wantError: true},
+		{name: "rejects path on TCP", value: "/api", declared: true, serviceProtocol: "tcp", wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseServicePath(tt.value, tt.declared, tt.serviceProtocol)
+			if tt.wantError {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("parseServicePath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestManagedContainerDetection(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/docker/cloud.go
+++ b/docker/cloud.go
@@ -293,6 +293,14 @@ func cloudServiceFromLabels(id, fullID, containerName string, labels map[string]
 			servicePort = targetPort
 		}
 	}
+	servicePathLabel, hasServicePath := labels[prefix+"path"]
+	if prefix == "" {
+		servicePathLabel, hasServicePath = labels[apptypes.LabelServicePath]
+	}
+	servicePath, pathErr := parseServicePath(servicePathLabel, hasServicePath, serviceProtocol)
+	if pathErr != nil {
+		servicePath = ""
+	}
 
 	return &apptypes.ContainerService{
 		ContainerID:     id,
@@ -302,6 +310,7 @@ func cloudServiceFromLabels(id, fullID, containerName string, labels map[string]
 		Port:            servicePort,
 		TargetPort:      targetPort,
 		ServiceProtocol: serviceProtocol,
+		ServicePath:     servicePath,
 		Protocol:        protocol,
 		Tags:            tags,
 	}

--- a/docs/04-labels.md
+++ b/docs/04-labels.md
@@ -31,6 +31,7 @@ Set `docktail.service.direct=false` to use published host ports instead. Use thi
 | `docktail.service.protocol` | No | Smart | Backend protocol. |
 | `docktail.service.service-port` | No | Smart | Port Tailscale listens on. |
 | `docktail.service.service-protocol` | No | Smart | Tailscale-facing protocol. |
+| `docktail.service.path` | No | `/` | URL path for HTTP(S) Serve traffic. Must start with `/`; not valid for TCP services. |
 | `docktail.service.proxy-protocol` | No | off | PROXY protocol version (`1` or `2`) prepended on TCP forwards so the backend sees the tailnet client address. Only valid with `service-protocol` `tcp` or `tls-terminated-tcp`. |
 | `docktail.tags` | No | `tag:container` | Comma-separated service tags. Labels are the source of truth; see the note below. |
 
@@ -41,7 +42,18 @@ Smart defaults:
 - `docktail.service.protocol` defaults to `https` when the backend port is `443`; otherwise it defaults to `http`.
 - `docktail.service.service-port` defaults to `443` when `service-protocol` is `https`; otherwise it defaults to `80`.
 - `docktail.service.service-protocol` defaults to `https` when the service port is `443`, to `tcp` when the backend protocol is TCP, and otherwise to `http`.
+- `docktail.service.path` defaults to `/` and is passed to `tailscale serve --set-path`. Changing or removing the label reconciles the old handler before advertising the new path.
 - `docktail.service.proxy-protocol` is opt-in and off by default. The backend must understand PROXY protocol; sending the header to something that does not (Postgres, Redis, raw TCP apps) will break the connection. Set it to `2` unless you specifically need version `1`. The label is rejected on HTTP/HTTPS services because Tailscale only supports PROXY protocol for TCP forwarding.
+
+To expose an HTTP(S) service below a custom path:
+
+```yaml
+labels:
+  - "docktail.service.enable=true"
+  - "docktail.service.name=api"
+  - "docktail.service.port=8000"
+  - "docktail.service.path=/api"
+```
 
 ### Multiple Services From One Container
 
@@ -59,7 +71,7 @@ services:
       - "docktail.service.1.port=8001"
 ```
 
-Each indexed service requires its own `name` and `port`. Per-index overridable labels are `name`, `port`, `service-port`, `protocol`, `service-protocol`, `proxy-protocol`, and `description`. Tags and network settings are inherited from the primary service config.
+Each indexed service requires its own `name` and `port`. Per-index overridable labels are `name`, `port`, `service-port`, `protocol`, `service-protocol`, `path`, `proxy-protocol`, and `description`. Tags and network settings are inherited from the primary service config.
 
 ### Funnel Labels
 

--- a/docs/07-reference.md
+++ b/docs/07-reference.md
@@ -59,6 +59,8 @@ Tailscale-facing `docktail.service.service-protocol` values:
 | `tcp` | Layer 4 TCP. |
 | `tls-terminated-tcp` | Layer 4 TCP; Tailscale terminates incoming TLS and forwards decrypted TCP to the backend. |
 
+`docktail.service.path` selects the HTTP(S) Serve mount point and defaults to `/`. It must start with `/` and is rejected for TCP protocols.
+
 `docktail.service.proxy-protocol` (`1` or `2`) is valid only with `tcp` or `tls-terminated-tcp`. It is off by default because the backend must understand the PROXY header. HTTP/HTTPS values are rejected.
 
 Container-facing `docktail.service.protocol` values:

--- a/e2e.sh
+++ b/e2e.sh
@@ -307,6 +307,17 @@ assert_service_destination_contains() {
     fi
 }
 
+# Check the configured HTTP(S) handler path.
+assert_service_path() {
+    local name="svc:$1"
+    local expected_path="$2"
+    if echo "$SERVE_STATUS_CACHE" | jq -e --arg name "$name" --arg path "$expected_path" '.Services[$name].Web[].Handlers[$path].Proxy? | strings | select(length > 0)' >/dev/null 2>&1; then
+        pass "$name serves path $expected_path"
+    else
+        fail "$name path $expected_path not found"
+    fi
+}
+
 # Check funnel status
 get_funnel_status() {
     docker exec "$TS_CONTAINER" tailscale funnel status --json 2>/dev/null || echo "{}"
@@ -535,6 +546,7 @@ assert_service_exists       "e2e-proto-http"
 assert_service_port         "e2e-proto-http" "80"
 assert_service_protocol     "e2e-proto-http" "http"
 assert_service_destination_contains "e2e-proto-http" "http://"
+assert_service_path         "e2e-proto-http" "/api"
 
 echo "  --- HTTPS ---"
 assert_service_exists       "e2e-proto-https"

--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -126,6 +126,7 @@ type ServiceEndpoint struct {
 	ServiceName   string // e.g., "svc:web"
 	Port          string // e.g., "443"
 	Protocol      string // e.g., "http", "https", "tcp"
+	Path          string // HTTP(S) handler path, empty for TCP
 	Destination   string // e.g., "http://localhost:9080"
 	ProxyProtocol int    // 0, 1, or 2 as reported by `tailscale serve status`
 }
@@ -202,6 +203,7 @@ func (c *Client) ReconcileServices(ctx context.Context, desiredServices []*appty
 	// Track what we need to add and remove
 	toAdd := make(map[string]*apptypes.ContainerService)
 	toRemove := make(map[string]ServiceEndpoint)
+	pathsToRemove := make(map[string]ServiceEndpoint)
 
 	// Find services to add (in desired but not in current, or changed)
 	for key, desired := range desiredMap {
@@ -216,6 +218,10 @@ func (c *Client) ReconcileServices(ctx context.Context, desiredServices []*appty
 			// Service exists - check if configuration changed
 			if serviceConfigChanged(current, desired) {
 				toAdd[key] = desired
+				if (current.Protocol == "http" || current.Protocol == "https") &&
+					normalizeServicePath(current.Path) != normalizeServicePath(desired.ServicePath) {
+					pathsToRemove[key] = current
+				}
 				log.Info().
 					Str("key", key).
 					Str("service", desired.ServiceName).
@@ -223,6 +229,8 @@ func (c *Client) ReconcileServices(ctx context.Context, desiredServices []*appty
 					Str("expected_dest", buildDestination(desired)).
 					Str("current_protocol", current.Protocol).
 					Str("expected_protocol", desired.ServiceProtocol).
+					Str("current_path", current.Path).
+					Str("expected_path", desired.ServicePath).
 					Int("current_proxy_protocol", current.ProxyProtocol).
 					Int("expected_proxy_protocol", desired.ProxyProtocol).
 					Msg("Service configuration changed, will update")
@@ -283,6 +291,17 @@ func (c *Client) ReconcileServices(ctx context.Context, desiredServices []*appty
 	failCount := 0
 
 	for key, svc := range toAdd {
+		if current, ok := pathsToRemove[key]; ok {
+			if err := c.removeServicePath(ctx, current); err != nil {
+				failCount++
+				log.Error().
+					Err(err).
+					Str("service", current.ServiceName).
+					Str("path", current.Path).
+					Msg("Failed to remove old service path")
+				continue
+			}
+		}
 		log.Info().
 			Str("container", svc.ContainerName).
 			Str("service", svc.ServiceName).

--- a/tailscale/service.go
+++ b/tailscale/service.go
@@ -69,7 +69,7 @@ func parseManagedServices(status TailscaleStatus) map[string]ServiceEndpoint {
 		// Parse TCP config to get port, protocol and destination
 		for port, tcpConfig := range svcConfig.TCP {
 			protocol := serviceProtocol(tcpConfig)
-			destination := serviceDestination(svcConfig, port, tcpConfig)
+			path, destination := serviceHandler(svcConfig, port, tcpConfig)
 
 			// Create a unique key for this service+port combination
 			key := fmt.Sprintf("%s:%s", serviceName, port)
@@ -78,6 +78,7 @@ func parseManagedServices(status TailscaleStatus) map[string]ServiceEndpoint {
 				ServiceName:   serviceName,
 				Port:          port,
 				Protocol:      protocol,
+				Path:          path,
 				Destination:   destination,
 				ProxyProtocol: tcpConfig.ProxyProtocol,
 			}
@@ -86,6 +87,7 @@ func parseManagedServices(status TailscaleStatus) map[string]ServiceEndpoint {
 				Str("service", serviceName).
 				Str("port", port).
 				Str("protocol", protocol).
+				Str("path", path).
 				Str("destination", destination).
 				Msg("Parsed existing service")
 		}
@@ -114,24 +116,29 @@ func serviceProtocol(tcpConfig TailscaleTCPConfig) string {
 // the destination was only read from the Web section, which is empty for plain
 // TCP services; that left their destination empty and made reconciliation treat
 // every TCP service as changed, re-adding it on each cycle (issue #56).
-func serviceDestination(svcConfig TailscaleService, port string, tcpConfig TailscaleTCPConfig) string {
+func serviceHandler(svcConfig TailscaleService, port string, tcpConfig TailscaleTCPConfig) (string, string) {
 	if !tcpConfig.HTTP && !tcpConfig.HTTPS {
-		return tcpConfig.TCPForward
+		return "", tcpConfig.TCPForward
 	}
 
 	for webKey, webConfig := range svcConfig.Web {
 		// Find the matching port in the web key
 		if strings.Contains(webKey, ":"+port) {
-			for _, handler := range webConfig.Handlers {
+			for path, handler := range webConfig.Handlers {
 				if handler.Proxy != "" {
-					return handler.Proxy
+					return path, handler.Proxy
 				}
 			}
 			break
 		}
 	}
 
-	return ""
+	return "", ""
+}
+
+func serviceDestination(svcConfig TailscaleService, port string, tcpConfig TailscaleTCPConfig) string {
+	_, destination := serviceHandler(svcConfig, port, tcpConfig)
+	return destination
 }
 
 // serveAddArgs builds `tailscale serve` arguments for advertising one service.
@@ -163,6 +170,9 @@ func serveAddArgs(svc *apptypes.ContainerService) ([]string, error) {
 	if svc.ProxyProtocol != 0 {
 		args = append(args, fmt.Sprintf("--proxy-protocol=%d", svc.ProxyProtocol))
 	}
+	if svc.ServiceProtocol == "http" || svc.ServiceProtocol == "https" {
+		args = append(args, fmt.Sprintf("--set-path=%s", normalizeServicePath(svc.ServicePath)))
+	}
 	args = append(args, destination)
 	return args, nil
 }
@@ -187,6 +197,7 @@ func (c *Client) addService(ctx context.Context, svc *apptypes.ContainerService)
 		Str("service_port", svc.Port).
 		Str("backend_protocol", svc.Protocol).
 		Int("proxy_protocol", svc.ProxyProtocol).
+		Str("service_path", svc.ServicePath).
 		Str("destination", destination).
 		Msg("Executing tailscale serve command")
 
@@ -254,6 +265,35 @@ func (c *Client) addService(ctx context.Context, svc *apptypes.ContainerService)
 		Msg("Service added successfully")
 
 	return nil
+}
+
+// removeServicePath removes one HTTP(S) handler before a path change. A serve
+// invocation adds or updates a mount point but does not remove the previous
+// one, so the original flags must be replayed with "off".
+func (c *Client) removeServicePath(ctx context.Context, svc ServiceEndpoint) error {
+	args, err := serveRemovePathArgs(svc)
+	if err != nil {
+		return err
+	}
+	cmd := c.tailscaleCmd(ctx, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to remove old service path: %w\nOutput: %s", err, string(output))
+	}
+	return nil
+}
+
+func serveRemovePathArgs(svc ServiceEndpoint) ([]string, error) {
+	if svc.Protocol != "http" && svc.Protocol != "https" {
+		return nil, fmt.Errorf("service path is unsupported for protocol %s", svc.Protocol)
+	}
+	return []string{
+		"serve",
+		fmt.Sprintf("--service=%s", svc.ServiceName),
+		fmt.Sprintf("--%s=%s", svc.Protocol, svc.Port),
+		fmt.Sprintf("--set-path=%s", normalizeServicePath(svc.Path)),
+		"off",
+	}, nil
 }
 
 // clearServiceOnly clears a service configuration without draining

--- a/tailscale/service.go
+++ b/tailscale/service.go
@@ -136,11 +136,6 @@ func serviceHandler(svcConfig TailscaleService, port string, tcpConfig Tailscale
 	return "", ""
 }
 
-func serviceDestination(svcConfig TailscaleService, port string, tcpConfig TailscaleTCPConfig) string {
-	_, destination := serviceHandler(svcConfig, port, tcpConfig)
-	return destination
-}
-
 // serveAddArgs builds `tailscale serve` arguments for advertising one service.
 // --proxy-protocol is included only when the label requested a version; Tailscale
 // rejects that flag on HTTP/HTTPS, so callers must already have validated it.

--- a/tailscale/service_test.go
+++ b/tailscale/service_test.go
@@ -284,6 +284,9 @@ func TestParseManagedServicesDestinations(t *testing.T) {
 	if web.Destination != "http://172.17.0.2:8080" {
 		t.Errorf("svc:web destination = %q, want http://172.17.0.2:8080", web.Destination)
 	}
+	if web.Path != "/" {
+		t.Errorf("svc:web path = %q, want /", web.Path)
+	}
 
 	db, ok := got["svc:db:5432"]
 	if !ok {
@@ -370,7 +373,19 @@ func TestServeAddArgs(t *testing.T) {
 				svc.ServiceProtocol = "https"
 				svc.TargetPort = "3000"
 			},
-			want: []string{"serve", "--service=svc:api", "--https=443", "http://172.17.0.5:3000"},
+			want: []string{"serve", "--service=svc:api", "--https=443", "--set-path=/", "http://172.17.0.5:3000"},
+		},
+		{
+			name: "http with custom path",
+			mutate: func(svc *apptypes.ContainerService) {
+				svc.ServiceName = "api"
+				svc.Port = "80"
+				svc.Protocol = "http"
+				svc.ServiceProtocol = "http"
+				svc.ServicePath = "/api"
+				svc.TargetPort = "3000"
+			},
+			want: []string{"serve", "--service=svc:api", "--http=80", "--set-path=/api", "http://172.17.0.5:3000"},
 		},
 		{
 			name: "unsupported protocol",
@@ -406,6 +421,27 @@ func TestServeAddArgs(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestServeRemovePathArgs(t *testing.T) {
+	got, err := serveRemovePathArgs(ServiceEndpoint{
+		ServiceName: "svc:api",
+		Port:        "443",
+		Protocol:    "https",
+		Path:        "/old",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"serve", "--service=svc:api", "--https=443", "--set-path=/old", "off"}
+	if len(got) != len(want) {
+		t.Fatalf("serveRemovePathArgs() = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("serveRemovePathArgs() = %#v, want %#v", got, want)
+		}
 	}
 }
 
@@ -451,6 +487,23 @@ func TestServiceConfigChanged(t *testing.T) {
 	current.ProxyProtocol = 0
 	if serviceConfigChanged(current, desired) {
 		t.Fatal("matching config without proxy-protocol should not look changed")
+	}
+
+	desired.Protocol = "http"
+	desired.ServiceProtocol = "https"
+	desired.ServicePath = "/api"
+	desired.Port = "443"
+	desired.TargetPort = "3000"
+	current.Protocol = "https"
+	current.Path = "/"
+	current.Port = "443"
+	current.Destination = "http://172.17.0.5:3000"
+	if !serviceConfigChanged(current, desired) {
+		t.Fatal("changing service path should be detected as a change")
+	}
+	current.Path = "/api"
+	if serviceConfigChanged(current, desired) {
+		t.Fatal("matching service path should not look changed")
 	}
 }
 

--- a/tailscale/utils.go
+++ b/tailscale/utils.go
@@ -189,13 +189,21 @@ func buildDestination(svc *apptypes.ContainerService) string {
 	return fmt.Sprintf("%s://%s:%s", svc.Protocol, svc.IPAddress, svc.TargetPort)
 }
 
+func normalizeServicePath(path string) string {
+	if path == "" {
+		return "/"
+	}
+	return path
+}
+
 // serviceConfigChanged reports whether the advertised endpoint differs from the
-// desired container labels. Destination, Tailscale-facing protocol, and PROXY
-// protocol version are all compared so enabling, changing, or removing
-// --proxy-protocol is picked up on the next reconcile.
+// desired container labels. Path is compared only for HTTP(S), where an empty
+// desired value represents the default root handler.
 func serviceConfigChanged(current ServiceEndpoint, desired *apptypes.ContainerService) bool {
 	expectedDest := buildDestination(desired)
 	return !sameDestination(current.Destination, expectedDest) ||
 		current.Protocol != desired.ServiceProtocol ||
-		current.ProxyProtocol != desired.ProxyProtocol
+		current.ProxyProtocol != desired.ProxyProtocol ||
+		((desired.ServiceProtocol == "http" || desired.ServiceProtocol == "https") &&
+			normalizeServicePath(current.Path) != normalizeServicePath(desired.ServicePath))
 }

--- a/types/types.go
+++ b/types/types.go
@@ -10,6 +10,7 @@ type ContainerService struct {
 	Port               string   // Tailscale service port (e.g., "443")
 	TargetPort         string   // Container/host port to proxy to (e.g., "9080")
 	ServiceProtocol    string   // Protocol Tailscale uses (e.g., "https", "http", "tcp")
+	ServicePath        string   // HTTP(S) Serve path (for example "/" or "/api")
 	Protocol           string   // Protocol the container speaks (e.g., "http", "https", "tcp")
 	Tags               []string // Tailscale service tags (e.g., ["tag:container", "tag:web"])
 	IPAddress          string
@@ -55,6 +56,7 @@ const (
 	LabelDescription      = "docktail.service.description"
 	LabelPort             = "docktail.service.service-port"
 	LabelServiceProtocol  = "docktail.service.service-protocol"
+	LabelServicePath      = "docktail.service.path"
 	LabelTarget           = "docktail.service.port"
 	LabelTargetProtocol   = "docktail.service.protocol"
 	LabelProxyProtocol    = "docktail.service.proxy-protocol"


### PR DESCRIPTION
Closes #84.

Adds `docktail.service.path` support for HTTP(S) services via `tailscale serve --set-path`, including indexed services, path-change reconciliation, documentation, unit coverage, and a live e2e assertion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP and HTTPS services can now be mounted at custom paths, such as `/api`.
  * Added support for configuring service paths through labels, with `/` as the default.
  * Service updates automatically remove outdated paths before applying new ones.

* **Bug Fixes**
  * Invalid paths and paths used with unsupported protocols are rejected.

* **Documentation**
  * Added guidance and examples for configuring HTTP(S) service paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->